### PR TITLE
Fix proxy usage with content_gateway

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,18 +2,18 @@ PATH
   remote: .
   specs:
     content_gateway (0.5.0)
-      activesupport
-      json
-      rest-client
+      activesupport (>= 3)
+      json (~> 1.0)
+      rest-client (~> 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.1.8)
-      i18n (~> 0.6, >= 0.6.9)
+    activesupport (4.2.5)
+      i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
-      thread_safe (~> 0.1)
+      thread_safe (~> 0.3, >= 0.3.4)
       tzinfo (~> 1.1)
     byebug (3.5.1)
       columnize (~> 0.8)
@@ -22,13 +22,18 @@ GEM
     columnize (0.8.9)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
-    i18n (0.6.11)
-    json (1.8.1)
-    mime-types (2.4.3)
-    minitest (5.5.0)
+    domain_name (0.5.25)
+      unf (>= 0.0.5, < 1.0.0)
+    http-cookie (1.0.2)
+      domain_name (~> 0.5)
+    i18n (0.7.0)
+    json (1.8.3)
+    mime-types (2.6.2)
+    minitest (5.8.3)
     multi_json (1.7.9)
-    netrc (0.10.2)
-    rest-client (1.7.2)
+    netrc (0.11.0)
+    rest-client (1.8.0)
+      http-cookie (>= 1.0.2, < 2.0)
       mime-types (>= 1.16, < 3.0)
       netrc (~> 0.7)
     rspec (3.1.0)
@@ -48,9 +53,12 @@ GEM
       simplecov-html (~> 0.7.1)
     simplecov-html (0.7.1)
     slop (3.6.0)
-    thread_safe (0.3.4)
+    thread_safe (0.3.5)
     tzinfo (1.2.2)
       thread_safe (~> 0.1)
+    unf (0.1.4)
+      unf_ext
+    unf_ext (0.0.7.1)
 
 PLATFORMS
   ruby
@@ -60,3 +68,6 @@ DEPENDENCIES
   content_gateway!
   rspec (>= 2.3.0)
   simplecov (>= 0.7.1)
+
+BUNDLED WITH
+   1.10.6

--- a/content-gateway.gemspec
+++ b/content-gateway.gemspec
@@ -16,9 +16,9 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.require_paths = ["lib"]
 
-  gem.add_dependency "activesupport"
-  gem.add_dependency "rest-client"
-  gem.add_dependency "json"
+  gem.add_dependency "activesupport",                           ">= 3"
+  gem.add_dependency "rest-client",                             "~> 1.0"
+  gem.add_dependency "json",                                    "~> 1.0"
 
   gem.add_development_dependency "rspec",                       ">= 2.3.0"
   gem.add_development_dependency "simplecov",                   ">= 0.7.1"

--- a/lib/content_gateway/request.rb
+++ b/lib/content_gateway/request.rb
@@ -6,11 +6,16 @@ module ContentGateway
         h[:headers] = headers if headers.present?
         h = load_ssl_params(h, params) if params.has_key?(:ssl_certificate)
       end
+      RestClient.proxy = proxy if proxy.present?
       @client = RestClient::Request.new(data)
     end
 
     def execute
-      @client.execute
+      data = @client.execute
+
+      RestClient.proxy = nil
+
+      data
 
     rescue RestClient::ResourceNotFound => e1
       raise ContentGateway::ResourceNotFound.new url, e1

--- a/lib/content_gateway/request.rb
+++ b/lib/content_gateway/request.rb
@@ -6,16 +6,12 @@ module ContentGateway
         h[:headers] = headers if headers.present?
         h = load_ssl_params(h, params) if params.has_key?(:ssl_certificate)
       end
-      RestClient.proxy = proxy if proxy.present?
+      RestClient.proxy = proxy
       @client = RestClient::Request.new(data)
     end
 
     def execute
-      data = @client.execute
-
-      RestClient.proxy = nil
-
-      data
+      @client.execute
 
     rescue RestClient::ResourceNotFound => e1
       raise ContentGateway::ResourceNotFound.new url, e1

--- a/spec/unit/content_gateway/request_spec.rb
+++ b/spec/unit/content_gateway/request_spec.rb
@@ -171,5 +171,17 @@ describe ContentGateway::Request do
         end
       end
     end
+
+    context "when proxy is used" do
+      let(:proxy) { 'http://proxy.test:3128' }
+      subject { ContentGateway::Request.new(:get, "/url", {}, {}, proxy) }
+      let(:request_params) { { method: :get, url: "/url", proxy: proxy } }
+
+      it "should set proxy on RestClient" do
+        expect(subject.execute).to eql "data"
+        expect(RestClient.proxy).to eql(proxy)
+      end
+    end
+
   end
 end


### PR DESCRIPTION
The last version of RestClient is 1.8.0 (https://github.com/rest-client/rest-client/tree/v1.8.0).
In this version the proxy usage is set with RestClient.proxy = '' 