### PR TITLE
Default value for stale_on_error

### DIFF
--- a/Changelog
+++ b/Changelog
@@ -1,3 +1,7 @@
+2016-11-07 [0.5.2]
+
+  * Bugfix: Now stale_on_error returns true if theres no config
+
 2015-11-19 [0.5.1]
 
   * Bugfix proxy implementation wrapper on rest-client

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    content_gateway (0.5.0)
+    content_gateway (0.5.1)
       activesupport (>= 3)
       json (~> 1.0)
       rest-client (~> 1.0)
@@ -9,7 +9,7 @@ PATH
 GEM
   remote: https://rubygems.org/
   specs:
-    activesupport (4.2.5)
+    activesupport (4.2.7.1)
       i18n (~> 0.7)
       json (~> 1.7, >= 1.7.7)
       minitest (~> 5.1)
@@ -22,14 +22,14 @@ GEM
     columnize (0.8.9)
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
-    domain_name (0.5.25)
+    domain_name (0.5.20161021)
       unf (>= 0.0.5, < 1.0.0)
-    http-cookie (1.0.2)
+    http-cookie (1.0.3)
       domain_name (~> 0.5)
     i18n (0.7.0)
     json (1.8.3)
-    mime-types (2.6.2)
-    minitest (5.8.3)
+    mime-types (2.99.3)
+    minitest (5.9.1)
     multi_json (1.7.9)
     netrc (0.11.0)
     rest-client (1.8.0)
@@ -58,7 +58,7 @@ GEM
       thread_safe (~> 0.1)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.7.1)
+    unf_ext (0.0.7.2)
 
 PLATFORMS
   ruby
@@ -69,5 +69,8 @@ DEPENDENCIES
   rspec (>= 2.3.0)
   simplecov (>= 0.7.1)
 
+RUBY VERSION
+   ruby 2.0.0p598
+
 BUNDLED WITH
-   1.10.6
+   1.13.6

--- a/lib/content_gateway/cache.rb
+++ b/lib/content_gateway/cache.rb
@@ -62,7 +62,7 @@ module ContentGateway
     private
     def config_stale_on_error params, config
       return params[:stale_on_error] unless params[:stale_on_error].nil?
-      return @config.stale_on_error unless @config.stale_on_error.nil?
+      return config.stale_on_error unless config.try(:stale_on_error).nil?
       true
     end
   end

--- a/lib/content_gateway/version.rb
+++ b/lib/content_gateway/version.rb
@@ -1,3 +1,3 @@
 module ContentGateway
-  VERSION = "0.5.1"
+  VERSION = "0.5.2"
 end

--- a/spec/integration/content_gateway/gateway_spec.rb
+++ b/spec/integration/content_gateway/gateway_spec.rb
@@ -8,11 +8,24 @@ describe ContentGateway::Gateway do
   end
 
   let! :config do
-    OpenStruct.new(
+    class FakeConfig
+      attr_accessor :cache, :cache_expires_in, :cache_stale_expires_in, :proxy, :timeout
+
+      def initialize(params)
+        @cache = params[:cache]
+        @cache_expires_in = params[:cache_expires_in]
+        @cache_stale_expires_in = params[:cache_stale_expires_in]
+        @proxy = params[:proxy]
+        @timeout = params[:timeout]
+      end
+    end
+
+    FakeConfig.new(
       cache: ActiveSupport::Cache::NullStore.new,
       cache_expires_in: 15.minutes,
       cache_stale_expires_in: 1.hour,
-      proxy: "proxy"
+      proxy: "proxy",
+      timeout: 2
     )
   end
 
@@ -123,9 +136,10 @@ describe ContentGateway::Gateway do
         end
 
         context "with stale cache" do
+          let(:cache_store) {double("cache_store")}
+
           context "on timeout" do
             before do
-              cache_store = double("cache_store")
               allow(cache_store).to receive(:fetch).with(resource_url, expires_in: default_expires_in).and_raise(Timeout::Error)
               allow(cache_store).to receive(:read).with(stale_cache_key).and_return(cached_response)
               config.cache = cache_store
@@ -140,36 +154,27 @@ describe ContentGateway::Gateway do
             before do
               stub_request_with_error({method: :get, url: resource_url, proxy: config.proxy, headers: headers}, RestClient::InternalServerError.new(nil, 500))
 
-              cache_store = double("cache_store")
               allow(cache_store).to receive(:fetch).with(resource_url, expires_in: default_expires_in).and_yield
               allow(cache_store).to receive(:read).with(stale_cache_key).and_return(cached_response)
               config.cache = cache_store
             end
 
-            it "should serve stale" do
-              expect(gateway.get(resource_path)).to eql "cached response"
-            end
-
-            context "when stale_on_error configuration is true" do
-              let :gateway do
-                config_with_stale_on_error = config.dup
-                config_with_stale_on_error.stale_on_error = true
-                ContentGateway::Gateway.new "API XPTO", config_with_stale_on_error, url_generator, headers: headers
-              end
-
-              it "should serve stale" do
-                expect(gateway.get(resource_path)).to eql "cached response"
+            context "give a config without stale_on_error"
+              context "uses the default value" do
+                it "returns cached stale" do
+                  expect(gateway.get(resource_path)).to eql "cached response"
+                end
               end
             end
 
             context "when stale_on_error configuration is false" do
               let :gateway do
                 config_with_stale_on_error = config.dup
-                config_with_stale_on_error.stale_on_error = false
+                allow(config_with_stale_on_error).to receive(:stale_on_error).and_return(false)
                 ContentGateway::Gateway.new "API XPTO", config_with_stale_on_error, url_generator, headers: headers
               end
 
-              it "should raise error" do
+              it "raises error" do
                 expect { gateway.get resource_path }.to raise_error ContentGateway::ServerError
               end
             end


### PR DESCRIPTION
Returns true if theres no config for stale_on_error(method_missing), typo and improves specs to use FakeConfig instead of OpenStruct